### PR TITLE
feat: dealing with unknown properties

### DIFF
--- a/notion_exporter/property_converter.py
+++ b/notion_exporter/property_converter.py
@@ -43,7 +43,14 @@ class PropertyConverter:
         Converts a Notion property to a Markdown string.
         """
         property_type = property_item["type"]
-        return self.type_specific_converters[property_type](property_item)
+        
+        if property_type in self.type_specific_converters:
+            return self.type_specific_converters[property_type](property_item)
+        else:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning(f"Unknown property type '{property_type}' encountered. Property data: {property_item}")
+            return f"[{property_type}: Unsupported property type]"
 
     @staticmethod
     def checkbox(property_item: dict) -> str:


### PR DESCRIPTION
Addressing

```
KeyError: 'button'

at .convert_property ( /usr/local/lib/python3.12/site-packages/notion_exporter/property_converter.py:46 )
```

not by adding button as there wasn't any documentation, but by in general dealing with new/unknown property types.